### PR TITLE
Fix MITM (http -> https)

### DIFF
--- a/build.js
+++ b/build.js
@@ -12,7 +12,7 @@ var debug = require('debug')('browser');
 
 var chromeVersion = '2.20';
 var phantomVersion = '1.9.7';
-var basePath = 'http://npm.taobao.org/mirrors/';
+var basePath = 'https://npm.taobao.org/mirrors/';
 var driversDest = path.resolve(__dirname, './driver');
 
 /**


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-node-browser

### ⚙️ Description *

The URL to import packages from was hardcoded to use the `http` version of the domain `npm.taobao.org`.

### 💻 Technical Description *

The fix just simply changes the `http` version to `https` to mitigate MITM attacks.

### 🐛 Proof of Concept (PoC) *

`node-browser` is a wrapper webdriver by Node.js, this package is vulnerable to Man in the Middle (MitM) attacks due to downloading resources over an insecure protocol.

Without a secure connection, it is possible for an attacker to intercept this connection and alter the packages received. In serious cases, this may even lead to Remote Code Execution (RCE) on the host server.

**Ref:** https://www.huntr.dev/bounties/1-npm-node-browser/

### 🔥 Proof of Fix (PoF) *

`basePath` changed to use `https` from `http` URL.

```javascript
var basePath = 'https://npm.taobao.org/mirrors/';
```

### 👍 User Acceptance Testing (UAT)

_No breaking changes._
